### PR TITLE
Feat/chap4 : HTTP client develop

### DIFF
--- a/chap4/connection_pool/go.mod
+++ b/chap4/connection_pool/go.mod
@@ -1,0 +1,3 @@
+module github.com/robert-min/handson-go/chap4/connection_pool
+
+go 1.19

--- a/chap4/connection_pool/main.go
+++ b/chap4/connection_pool/main.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptrace"
+	"os"
+	"time"
+)
+
+func createHTTPClientWithTimeout(d time.Duration) *http.Client {
+	client := http.Client{Timeout: d}
+	return &client
+}
+
+func createHTTPGetRequestWithTrace(ctx context.Context, url string) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	trace := &httptrace.ClientTrace{
+		DNSDone: func(dnsInfo httptrace.DNSDoneInfo) {
+			fmt.Printf("DNS Info: %+v\n", dnsInfo)
+		},
+		GotConn: func(connInfo httptrace.GotConnInfo) {
+			fmt.Printf("Got Conn: %+v\n", connInfo)
+		},
+		TLSHandshakeStart: func() {
+			fmt.Printf("TLS HandShake Start\n")
+		},
+		TLSHandshakeDone: func(connState tls.ConnectionState, err error) {
+			fmt.Printf("TLS HandShake Done\n")
+		},
+
+		PutIdleConn: func(err error) {
+			fmt.Printf("Put Idle Conn Error: %+v\n", err)
+		},
+	}
+	ctxTrace := httptrace.WithClientTrace(req.Context(), trace)
+	req = req.WithContext(ctxTrace)
+	return req, err
+}
+
+func main() {
+	d := 5 * time.Second
+	ctx := context.Background()
+	client := createHTTPClientWithTimeout(d)
+
+	req, err := createHTTPGetRequestWithTrace(ctx, os.Args[1])
+	if err != nil {
+		log.Fatal(err)
+	}
+	for {
+		resp, _ := client.Do(req)
+		io.Copy(ioutil.Discard, resp.Body)
+		resp.Body.Close()
+		fmt.Printf("Resp protocol: %#v\n", resp.Proto)
+		time.Sleep(1 * time.Second)
+		fmt.Println("--------")
+	}
+}

--- a/chap4/data_downloader/fetch_remote_resource_bad_server_test.go
+++ b/chap4/data_downloader/fetch_remote_resource_bad_server_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func startBadTestHTTPServer() *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// delay 60 seconds befor sending response to client
+		time.Sleep(60 * time.Second)
+		fmt.Fprint(w, "Hello World")
+	}))
+	return ts
+}
+
+func TestFetchBadRemoteResource(t *testing.T) {
+	ts := startBadTestHTTPServer()
+	defer ts.Close()
+
+	data, err := fetchRemoteResource(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := "Hello World"
+	got := string(data)
+
+	if expected != got {
+		t.Errorf("Expected response to be: %s, Got: %s", expected, got)
+	}
+}

--- a/chap4/data_downloader/go.mod
+++ b/chap4/data_downloader/go.mod
@@ -1,0 +1,3 @@
+module github.com/robert-min/handson-go/chap4/data_downloader
+
+go 1.19

--- a/chap4/data_downloader/main.go
+++ b/chap4/data_downloader/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+func fetchRemoteResource(url string) ([]byte, error) {
+	r, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+	return io.ReadAll(r.Body)
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stdout, "Must specify a HTTP URL to get data from")
+		os.Exit(1)
+	}
+	body, err := fetchRemoteResource(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stdout, "%v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stdout, "%s\n", body)
+}

--- a/chap4/data_downloader_redirect/main.go
+++ b/chap4/data_downloader_redirect/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+func fetchRemoteResource(client *http.Client, url string) ([]byte, error) {
+	r, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+	return io.ReadAll(r.Body)
+}
+
+func redirectPolicyFunc(req *http.Request, via []*http.Request) error {
+	if len(via) >= 1 {
+		return errors.New(fmt.Sprintf("Attempted redirect to %s", req.URL))
+	}
+	return nil
+}
+
+func createHTTPClientWithTimeout(d time.Duration) *http.Client {
+	client := http.Client{
+		Timeout:       d,
+		CheckRedirect: redirectPolicyFunc,
+	}
+	return &client
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stdout, "Must specify a HTTP URL to get data from")
+		os.Exit(1)
+	}
+	// set client timeout
+	client := createHTTPClientWithTimeout(15 * time.Second)
+
+	body, err := fetchRemoteResource(client, os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stdout, "%#v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stdout, "%s\n", body)
+}

--- a/chap4/data_downloader_timeout/fetch_remote_resource_bad_server_test.go
+++ b/chap4/data_downloader_timeout/fetch_remote_resource_bad_server_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func startBadTestHTTPServerV2(shutdownServer chan struct{}) *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-shutdownServer
+		fmt.Fprint(w, "Hello World")
+	}))
+	return ts
+}
+
+func TestFetchBadRemoteResourceV2(t *testing.T) {
+	shutdownServer := make(chan struct{})
+	ts := startBadTestHTTPServerV2(shutdownServer)
+	defer ts.Close()
+	defer func() {
+		shutdownServer <- struct{}{}
+	}()
+
+	client := createHTTPClientWithTimeout(200 * time.Millisecond)
+	_, err := fetchRemoteResource(client, ts.URL)
+	if err == nil {
+		t.Fatal("Expected non-nil error")
+	}
+
+	if !strings.Contains(err.Error(), "Client.Timeout exceeded while awaiting headers") {
+		t.Fatalf("Expected error to contain: Client.Timeout exceeded while awaiting headers, Got: %v", err.Error())
+	}
+}

--- a/chap4/data_downloader_timeout/go.mod
+++ b/chap4/data_downloader_timeout/go.mod
@@ -1,0 +1,3 @@
+module github.com/robert-min/handson-go/chap4/data_downloader_timeout
+
+go 1.19

--- a/chap4/data_downloader_timeout/main.go
+++ b/chap4/data_downloader_timeout/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+func fetchRemoteResource(client *http.Client, url string) ([]byte, error) {
+	r, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+	return io.ReadAll(r.Body)
+}
+
+func createHTTPClientWithTimeout(d time.Duration) *http.Client {
+	client := http.Client{Timeout: d}
+	return &client
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stdout, "Must specify a HTTP URL to get data from")
+		os.Exit(1)
+	}
+	// set client timeout
+	client := createHTTPClientWithTimeout(15 * time.Second)
+
+	body, err := fetchRemoteResource(client, os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stdout, "%#v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stdout, "%s\n", body)
+}

--- a/chap4/header_middleware/client.go
+++ b/chap4/header_middleware/client.go
@@ -1,0 +1,25 @@
+package client
+
+import "net/http"
+
+type AddHeadersMiddleware struct {
+	headers map[string]string
+}
+
+func (h AddHeadersMiddleware) RoundTrip(r *http.Request) (*http.Response, error) {
+	reqCopy := r.Clone(r.Context())
+	for k, v := range h.headers {
+		reqCopy.Header.Add(k, v)
+	}
+	return http.DefaultTransport.RoundTrip(reqCopy)
+}
+
+func createClient(headers map[string]string) *http.Client {
+	h := AddHeadersMiddleware{
+		headers: headers,
+	}
+	client := http.Client{
+		Transport: &h,
+	}
+	return &client
+}

--- a/chap4/header_middleware/go.mod
+++ b/chap4/header_middleware/go.mod
@@ -1,0 +1,3 @@
+module github.com/robert-min/handson-go/chap4/header_middleware
+
+go 1.19

--- a/chap4/header_middleware/header_middleware_test.go
+++ b/chap4/header_middleware/header_middleware_test.go
@@ -1,0 +1,39 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func startHTTPServer() *httptest.Server {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for k, v := range r.Header {
+			w.Header().Set(k, v[0])
+		}
+		fmt.Fprint(w, "I am the Request Header echoing program")
+	}))
+	return ts
+}
+
+func TestAddHeaderMiddleware(t *testing.T) {
+	testHeaders := map[string]string{
+		"X-Client-Id": "test-client",
+		"X-Auth-Hash": "random$string",
+	}
+	client := createClient(testHeaders)
+
+	ts := startHTTPServer()
+	defer ts.Close()
+
+	resp, err := client.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("Expected non-nil error, got: %v", err)
+	}
+	for k, v := range testHeaders {
+		if resp.Header.Get(k) != testHeaders[k] {
+			t.Fatalf("Expected header: %s:%s, Got: %s:%s", k, v, k, testHeaders[k])
+		}
+	}
+}

--- a/chap4/logging_middleware/go.mod
+++ b/chap4/logging_middleware/go.mod
@@ -1,0 +1,3 @@
+module github.com/robert-min/handson-go/chap4/logging_middleware
+
+go 1.19

--- a/chap4/logging_middleware/main.go
+++ b/chap4/logging_middleware/main.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"time"
+)
+
+type LoggingClient struct {
+	log *log.Logger
+}
+
+// Logging outgoing requests
+func (c LoggingClient) RoundTrip(r *http.Request) (*http.Response, error) {
+	c.log.Printf("Sending a %s request to %s over %s\n", r.Method, r.URL, r.Proto)
+	resp, err := http.DefaultTransport.RoundTrip(r)
+	c.log.Printf("Got back a response over %s\n", resp.Proto)
+
+	return resp, err
+}
+
+func fetchRemoteResource(client *http.Client, url string) ([]byte, error) {
+	r, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+	return io.ReadAll(r.Body)
+}
+
+func createHTTPClientWithTimeout(d time.Duration) *http.Client {
+	client := http.Client{Timeout: d}
+	return &client
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stdout, "Must specify a HTTP URL to get data from")
+		os.Exit(1)
+	}
+
+	myTransport := LoggingClient{}
+	// Create log.Logger object, 로그가 작성될 io 객체
+	l := log.New(os.Stdout, "", log.LstdFlags)
+	myTransport.log = l
+
+	client := createHTTPClientWithTimeout(15 * time.Second)
+	client.Transport = &myTransport
+
+	body, err := fetchRemoteResource(client, os.Args[1])
+	if err != nil {
+		fmt.Fprintln(os.Stdout, "%#v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stdout, "Bytes in response: %d\n", len(body))
+}


### PR DESCRIPTION
### 주요 변경점
- Custom timeout
- redirect
- Logging middleware
- Header middleware
- Connection pooling

### 상세 변경점

- Chapter4. HTTP Client - 과부화 서버, Custom timout, redirect [링크](https://github.com/robert-min/handson-go/issues/11)
- Chapter4. HTTP client - Logging middleware, Header middleware, Connection pool [링크](https://github.com/robert-min/handson-go/issues/12)

